### PR TITLE
Update node version and remove ruby as a dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # This is totally hacked from the circleci container builds...
 
-FROM node:6.11
+# Node 8 started LTS on 2017-10-31
+# Node 10 will start LTS on 2018-10
+FROM node:8
 
 # make Apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,6 @@ RUN groupadd --gid 3434 circleci \
 
 # BEGIN IMAGE CUSTOMIZATIONS
 
-RUN apt-get install -y ruby ruby-dev \
-  && gem install bundler --no-rdoc --no-ri
-
 # END IMAGE CUSTOMIZATIONS
 
 USER circleci


### PR DESCRIPTION
Updated node to latest LTS version (8). Also, now that we no longer have legacy deploys requiring ruby we can get rid of this dependency.